### PR TITLE
feat: ui cleanup

### DIFF
--- a/src/components/widgets/toolhead/Toolhead.vue
+++ b/src/components/widgets/toolhead/Toolhead.vue
@@ -7,14 +7,14 @@
         justify="space-between"
         align="start"
       >
-        <v-col class="controls-wrapper">
+        <v-col class="mx-auto controls-wrapper">
           <extruder-selection v-if="hasMultipleExtruders" />
           <toolhead-control-cross v-if="!printerPrinting && toolheadControlStyle === 'cross'" />
           <toolhead-control-bars v-else-if="!printerPrinting && toolheadControlStyle === 'bars'" />
           <z-height-adjust v-if="printerPrinting" />
         </v-col>
 
-        <v-col class="controls-wrapper">
+        <v-col class="mx-auto controls-wrapper">
           <toolhead-position />
           <extruder-moves v-if="!printerPrinting && hasExtruder" />
           <z-height-adjust v-if="!printerPrinting" />


### PR DESCRIPTION
feat: ui cleanup

- center the toolhead controls, looks a bit neater.

![image](https://github.com/vajonam/fluidd/assets/152501/f3ed9996-9c00-45af-9e37-249e49863fcc)

Signed-off-by: vajonam <vajonam@github>

